### PR TITLE
ci: fix typo in file name of e2e-test logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
           path: 'packages/e2e-testing'
           command: 'yarn test:e2e'
       - store_artifacts:
-          path: /tmp/e2e-test-without-ledger-without-chain.log
+          path: /tmp/e2e-test-with-ledger-without-chain.log
       - store_artifacts:
           path: /tmp/e2e-test-without-ledger-without-chain.log
 


### PR DESCRIPTION
Fixes https://github.com/statechannels/project-management/issues/37
