### PR TITLE
 skip prepare during github action

### DIFF
--- a/.github/workflows/upgrade-statechannels-next.yml
+++ b/.github/workflows/upgrade-statechannels-next.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  publish-to-npm:
+  update-statechannels-packages-to-next:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
@@ -46,3 +46,4 @@ jobs:
           branch: upgrade-statechannels-pkgs
           title: Upgrade @statechannels packages to @next tag
           body: This PR was created automatically by a github action.
+          commit-message: upgrade statechannels packages to next tag

--- a/.github/workflows/upgrade-statechannels-next.yml
+++ b/.github/workflows/upgrade-statechannels-next.yml
@@ -28,6 +28,8 @@ jobs:
             ${{ runner.os }}-yarn-cache-v2-
 
       - name: yarn install
+        env:
+          SKIP_PREPARE: true # the upgrades may well prevent our packages compiling
         run: |
           yarn workspace @graphprotocol/payments upgrade @statechannels/server-wallet@next @statechannels/client-api-schema@next @statechannels/wallet-core@next -E
           yarn workspace @graphprotocol/receipts upgrade @statechannels/server-wallet@next @statechannels/client-api-schema@next @statechannels/wallet-core@next -E


### PR DESCRIPTION
Recently the action is failing because the changes pulled in are dramatic enough to prevent the packages in this repo from compiling, let alone getting to the point where tests may be run. This means a PR is never raised with the changes.

https://github.com/statechannels/the-graph/actions

Solution: don't run the prepare step on this action (this will speed it up, to boot). It will run and fail on circle when the PR is raised.