### PR TITLE
ci: remove duplicated step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,6 @@ jobs:
       - run: git diff --exit-code
       - run: yarn lint:check
       - <<: *save_dep
-      - run: yarn test:ci
 
       - persist_to_workspace:
           root: ~/project


### PR DESCRIPTION
This step is also performed in the `test` job on circle. It doesn't belong in the `build` step and we can save time by removing it. 