### PR TITLE
fix: exit db-utils yargs script after async handler resolves

### DIFF
--- a/packages/payments/scripts/db-utils.ts
+++ b/packages/payments/scripts/db-utils.ts
@@ -10,16 +10,15 @@ async function dbScripts() {
         'migrate [dbConnection]',
         'Migrate the database',
         (args) => args.positional('dbConnection', {type: 'string', required: true}),
-        ({dbConnection}) => handleDBCommand('migrate', dbConnection)
+        ({dbConnection}) => handleDBCommand('migrate', dbConnection).then(process.exit(0))
       )
       .command(
         'create_schema [dbConnection]',
         'Creates necessesary database schema',
         (args) => args.positional('dbConnection', {type: 'string', required: true}),
-        ({dbConnection}) => handleDBCommand('create_schema', dbConnection)
+        ({dbConnection}) => handleDBCommand('create_schema', dbConnection).then(process.exit(0))
       )
       .help().argv;
-    process.exit(0);
   } catch (error) {
     console.error('Error occured migrating', error);
     process.exit(1);
@@ -66,9 +65,7 @@ async function handleDBCommand(
     await knex.raw('CREATE SCHEMA IF NOT EXISTS payment_manager');
     if (command === 'migrate') {
       console.log('Running cache migrations');
-
       await knex.migrate.latest();
-      process.exit(0);
     }
   } catch (error) {
     console.error('Error occured', error);

--- a/packages/payments/scripts/db-utils.ts
+++ b/packages/payments/scripts/db-utils.ts
@@ -4,21 +4,22 @@ import yargs from 'yargs';
 import {SCHEMA} from '../src/db/constants';
 import {parse} from 'pg-connection-string';
 async function dbScripts() {
+  const parser = yargs
+    .command(
+      'migrate [dbConnection]',
+      'Migrate the database',
+      (args) => args.positional('dbConnection', {type: 'string', required: true}),
+      ({dbConnection}) => handleDBCommand('migrate', dbConnection)
+    )
+    .command(
+      'create_schema [dbConnection]',
+      'Creates necessesary database schema',
+      (args) => args.positional('dbConnection', {type: 'string', required: true}),
+      ({dbConnection}) => handleDBCommand('create_schema', dbConnection)
+    )
+    .help();
   try {
-    yargs
-      .command(
-        'migrate [dbConnection]',
-        'Migrate the database',
-        (args) => args.positional('dbConnection', {type: 'string', required: true}),
-        ({dbConnection}) => handleDBCommand('migrate', dbConnection).then(process.exit(0))
-      )
-      .command(
-        'create_schema [dbConnection]',
-        'Creates necessesary database schema',
-        (args) => args.positional('dbConnection', {type: 'string', required: true}),
-        ({dbConnection}) => handleDBCommand('create_schema', dbConnection).then(process.exit(0))
-      )
-      .help().argv;
+    await parser.parse();
   } catch (error) {
     console.error('Error occured migrating', error);
     process.exit(1);
@@ -29,47 +30,43 @@ async function handleDBCommand(
   command: 'migrate' | 'create_schema',
   dbConnection: string | undefined
 ) {
-  try {
-    if (!dbConnection) {
-      throw new Error('No db connection provided');
-    }
+  if (!dbConnection) {
+    throw new Error('No db connection provided');
+  }
 
-    const BASE_PATH = path.join(__dirname, '../src/db');
-    const extensions = [path.extname(__filename)];
-    const parsedDbConnection = parse(dbConnection);
-    console.log(`Using db connection ${JSON.stringify(parsedDbConnection)}`);
-    const {host, port, user, database, password} = parsedDbConnection;
-    if (!database) {
-      throw new Error('No database provided');
+  const BASE_PATH = path.join(__dirname, '../src/db');
+  const extensions = [path.extname(__filename)];
+  const parsedDbConnection = parse(dbConnection);
+  console.log(`Using db connection ${JSON.stringify(parsedDbConnection)}`);
+  const {host, port, user, database, password} = parsedDbConnection;
+  if (!database) {
+    throw new Error('No database provided');
+  }
+  const knexConfig: Config = {
+    client: 'pg',
+    connection: {
+      ...parsedDbConnection,
+      // This is annoying but pg-connection-string returns null and undefined values
+      host: host || 'localhost',
+      port: port ? Number(port) : 5432,
+      user: user || 'postgres',
+      password: password || undefined,
+      database: database || undefined
+    },
+    migrations: {
+      directory: path.join(BASE_PATH, 'migrations'),
+      loadExtensions: extensions,
+      schemaName: SCHEMA
     }
-    const knexConfig: Config = {
-      client: 'pg',
-      connection: {
-        ...parsedDbConnection,
-        // This is annoying but pg-connection-string returns null and undefined values
-        host: host || 'localhost',
-        port: port ? Number(port) : 5432,
-        user: user || 'postgres',
-        password: password || undefined,
-        database: database || undefined
-      },
-      migrations: {
-        directory: path.join(BASE_PATH, 'migrations'),
-        loadExtensions: extensions,
-        schemaName: SCHEMA
-      }
-    };
+  };
 
-    const knex = Knex(knexConfig);
-    console.log('Creating schema if needed');
-    await knex.raw('CREATE SCHEMA IF NOT EXISTS payment_manager');
-    if (command === 'migrate') {
-      console.log('Running cache migrations');
-      await knex.migrate.latest();
-    }
-  } catch (error) {
-    console.error('Error occured', error);
-    process.exit(1);
+  const knex = Knex(knexConfig);
+  console.log('Creating schema if needed');
+  await knex.raw('CREATE SCHEMA IF NOT EXISTS payment_manager');
+  if (command === 'migrate') {
+    console.log('Running cache migrations');
+    await knex.migrate.latest();
   }
 }
+
 dbScripts();

--- a/packages/payments/scripts/db-utils.ts
+++ b/packages/payments/scripts/db-utils.ts
@@ -24,6 +24,7 @@ async function dbScripts() {
     console.error('Error occured migrating', error);
     process.exit(1);
   }
+  process.exit(0);
 }
 
 async function handleDBCommand(


### PR DESCRIPTION
The handlers in he db-utils yargs script are async: under the current implementation, the process may exit before the handler resolves. Even worse, the handler may not even complete at all. 

This change adopts a [more canonical approach to using async handlers with yargs](https://github.com/yargs/yargs/blob/master/docs/advanced.md#using-yargs-with-asyncawait), ensuring that the process only exits successfully if the desired database preparation has been successfully applied. It avoids a race condition. 

# How Has This Been Tested?

On my machine (but seemingly no one else's, including circle) the e2e tests were never passing. I would see
```
AIL  __tests__/e2e.test.ts (17.788 s)
  Payment & Receipt Managers E2E
    ✕ Can create and pay with 2 allocations (6652 ms)
    ✕ Can remove 2 allocations using syncAllocations (179 ms)
    ✕ Payment and Receipt can get back in sync if indexer offline (2102 ms)
    ✕ Payment and Receipt can get back in sync if payer missed receipt (1977 ms)
  ● Payment & Receipt Managers E2E › Can create and pay with 2 allocations
    Request failed with status code 406
      at createError (../../node_modules/axios/lib/core/createError.js:16:15)
      at settle (../../node_modules/axios/lib/core/settle.js:17:12)
      at IncomingMessage.handleStreamEnd (../../node_modules/axios/lib/adapters/http.js:244:11)
```

in the test, and 
```"type":"DatabaseError","message":"relation \"payment_manager.payment_channels\" does not exist","stack":"error: relation \"payment_manager.payment_channels\" does not exist``` in the logs.  This was indicative of certain database migrations failing to run (I think specifically that a schema was failing to be created). 

So the "test" was that this change suddenly caused my tests to pass locally 🎉 . 

Other evidence that this change was needed: 

- some of the `console.log` statements in the edited file were not getting printed out at all for me. 
- I spent a long time ensuring my local setup and commands were as close as possible to circle. A race condition is then quite a likely culprit if no obious/major differences remain. 


# Checklist:

## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [x] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://github.com/statechannels/statechannels/issues/3177)
- [x] I have linked to relevant issues
- [x] I have added dependent tickets
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline