### PR TITLE
Only warm up threads if the wallet is multi-threaded

### DIFF
--- a/packages/payments/src/payment-manager.ts
+++ b/packages/payments/src/payment-manager.ts
@@ -2,7 +2,8 @@ import {Histogram, Counter} from 'prom-client';
 import {Logger, Metrics, timed} from '@graphprotocol/common-ts';
 import {
   Wallet as ChannelWallet,
-  IncomingServerWalletConfig as WalletConfig
+  IncomingServerWalletConfig as WalletConfig,
+  MultiThreadedWallet
 } from '@statechannels/server-wallet';
 import {Evt} from 'evt';
 
@@ -42,7 +43,8 @@ export class PaymentManager implements PaymentManagementAPI {
 
   static async create(opts: PaymentManagerOptions): Promise<PaymentManagementAPI> {
     const paymentManager = new PaymentManager(await ChannelWallet.create(opts.walletConfig), opts);
-    await paymentManager.wallet.warmUpThreads();
+    paymentManager.wallet instanceof MultiThreadedWallet &&
+      (await paymentManager.wallet.warmUpThreads());
     return paymentManager;
   }
 

--- a/packages/receipts/src/receipt-manager.ts
+++ b/packages/receipts/src/receipt-manager.ts
@@ -2,7 +2,8 @@ import {ChannelResult} from '@statechannels/client-api-schema';
 import {
   DBAdmin,
   Wallet,
-  IncomingServerWalletConfig as WalletConfig
+  IncomingServerWalletConfig as WalletConfig,
+  MultiThreadedWallet
 } from '@statechannels/server-wallet';
 import {Logger, NetworkContracts} from '@graphprotocol/common-ts';
 import {
@@ -44,6 +45,7 @@ export class ReceiptManager implements ReceiptManagerInterface {
     const wallet = await Wallet.create(walletConfig);
     await wallet.addSigningKey(makePrivateKey(privateKey));
     await wallet.registerAppBytecode(contracts.attestationApp.address, getAttestionAppByteCode());
+    wallet instanceof MultiThreadedWallet && (await wallet.warmUpThreads());
 
     return new ReceiptManager(logger, privateKey, contracts, wallet);
   }
@@ -54,7 +56,6 @@ export class ReceiptManager implements ReceiptManagerInterface {
     wallet: Wallet
   ) {
     this.wallet = wallet;
-    this.wallet.warmUpThreads();
   }
 
   async closeDBConnections(): Promise<void> {


### PR DESCRIPTION
Looking in my crystal ball, I anticipate that we will need to make this change to cope with breaking changes in the server wallet. 🔮 

Happily, the change does not break existing functionality, so can be merged now. 