### PR TITLE
ci: add github workflows for publishing to npm

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,39 @@
+name: Publish Packages (canary)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  canary-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          # pulls all commits and tags (needed for lerna / semantic release to correctly version)
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.16.3
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-yarn-cache-v2-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-v2-
+
+      - name: yarn install
+        # skip the prepare step here, as lerna publish will run prepare before publishing
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          SKIP_PREPARE=true yarn install
+
+      - name: Configure CI Git User
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: publish packages to npm
+        run: yarn run lerna publish --canary --force-publish --exact --preid next.$(git rev-parse --short HEAD) --dist-tag next --yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish Packages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          # pulls all commits and tags (needed for lerna / semantic release to correctly version)
+          fetch-depth: 0
+
+      - name: Check that we're on master
+        if: github.ref != 'refs/heads/master'
+        run: exit 1
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.16.3
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-yarn-cache-v2-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-v2-
+
+      - name: yarn install
+        # skip the prepare step here, as lerna publish will run prepare before publishing
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          SKIP_PREPARE=true yarn install
+
+      - name: Configure CI Git User
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: publish packages to npm
+        run: |
+          yarn run lerna version --conventional-commits --yes --exact --no-push --message "chore(release): publish [skip ci]"
+          yarn run lerna publish from-git --yes
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: update-master-with-published-versions
+          title: Updates published versions [please merge ASAP]
+          body: Updates to the versions and changelogs created by the `Publish Packages` action
+
+      - name: push commit tags
+        run: git push --tags


### PR DESCRIPTION
# Description

add github workflows for publishing to npm

Fixes https://github.com/statechannels/project-management/issues/33. This is mostly copy and paste from the previous codebase, with the commands to push to the testnet repos removed.

The summary may omit some of these details if this PR fixes a single ticket that includes these details. It is the reviewer's discretion. 

# How Has This Been Tested?

This hasn't been tested, as it can only really be tested on github (and on the `master` branch for `publish.yml`) . It worked in the old repo, but it isn't clear to me how lerna is going to handle publishing to the same npm package from a new repo, which doesn't have the old publish tags. I'm expecting to have to iterate a bit on github to get the publishing to work. 

# Still todo

- [x] Upload an `NPM_TOKEN` to github secrets for this repo
- [x] ~Decide whose npm token that should be (Maybe a bot? Previously it was mine, but then I get emailed every time a publish happens...)~ I just did mine again