### PR TITLE
Use ensureChannelsOpen to deal with race conditions

### DIFF
--- a/packages/payments/src/__tests__/payment-manager.test.ts
+++ b/packages/payments/src/__tests__/payment-manager.test.ts
@@ -264,7 +264,7 @@ describe('ChannelManager', () => {
 
     // sync allocations
     await channelManager.syncAllocations([request(fakeIndexer.allocation(allocationId))]);
-    expect(await channelManager.activeChannelCount(allocationId)).toEqual(2);
+    expect(await channelManager.activeChannelCount(allocationId)).toEqual(0);
 
     fakeIndexer.goOnline();
     const paymentManager = await TestPaymentManager.create({

--- a/packages/payments/src/channel-manager.ts
+++ b/packages/payments/src/channel-manager.ts
@@ -397,16 +397,16 @@ export class ChannelManager implements ChannelManagementAPI {
    * and then s yncs all channels for the resulting allocation
    */
   private async ensureChannelsOpen(initialMessage: Outgoing): Promise<ChannelResult[]> {
-    for (const retryTimeoutMs of [2_500, 5_000, 10_000, 20_000, 40_000]) {
-      const initialResults = await this.exchangeMessagesUntilOutboxIsEmpty(initialMessage);
+    let initialResults = await this.exchangeMessagesUntilOutboxIsEmpty(initialMessage);
 
+    for (const retryTimeoutMs of [2_500, 5_000, 10_000, 20_000, 40_000]) {
       const [running, notRunning] = _.partition(initialResults, ['status', 'running']);
-      this.logger.debug('Inserting channels into thing', {running, notRunning});
+
       if (notRunning.length === 0) return running;
 
       await delay(retryTimeoutMs);
 
-      this._syncChannels(_.map(notRunning, 'channelId'));
+      initialResults = await this._syncChannels(_.map(notRunning, 'channelId'));
     }
 
     throw new Error('Unable to ensure channels open');

--- a/packages/payments/src/channel-manager.ts
+++ b/packages/payments/src/channel-manager.ts
@@ -397,16 +397,16 @@ export class ChannelManager implements ChannelManagementAPI {
    * and then s yncs all channels for the resulting allocation
    */
   private async ensureChannelsOpen(initialMessage: Outgoing): Promise<ChannelResult[]> {
-    let initialResults = await this.exchangeMessagesUntilOutboxIsEmpty(initialMessage);
+    let channelResults = await this.exchangeMessagesUntilOutboxIsEmpty(initialMessage);
 
     for (const retryTimeoutMs of [2_500, 5_000, 10_000, 20_000, 40_000]) {
-      const [running, notRunning] = _.partition(initialResults, ['status', 'running']);
+      const [running, notRunning] = _.partition(channelResults, ['status', 'running']);
 
       if (notRunning.length === 0) return running;
 
       await delay(retryTimeoutMs);
 
-      initialResults = await this._syncChannels(_.map(notRunning, 'channelId'));
+      channelResults = await this._syncChannels(_.map(notRunning, 'channelId'));
     }
 
     throw new Error('Unable to ensure channels open');


### PR DESCRIPTION
Rewrite of #544. 

# Description
1. This shows one way you can fix https://github.com/statechannels/the-graph/issues/486
2. This also fixes a different bug, where channels finish their funding in different "rounds" of messaging

The fundamental issue with #486 is that the ChannelManager (CM) assumes that `exchangeMessagesUntilOutboxIsEmpty` resolves _precisely when_ when there is no message in the outbox. This is not the case, as #486 points out.

This problem is resolved by implementing a `ensureChannelsOpen` function, which ensures that channels get open. The current approach is WIP only:  I suggest one hacky way in which we can "ensure" that the channel is open. (In fact, I am making the assumption that waiting 10 seconds, syncing, and trying again will work. This is fragile.)

A more robust method would be to rely on "[first class objectives](https://www.notion.so/First-class-objectives-402f747da81b4bf38de1a3f28dd6ca31#0c8a74a41791478c9f70a10790b549e5)".

# How Has This Been Tested?

The code that has been changed is tested, though there is not a test yet for the specific race condition this test is intended to fix. 

# Checklist:

## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [ ] I have added tests that prove my fix is effective or that my feature works

## Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to relevant issues
- [ ] I have added dependent tickets
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline
