### PR TITLE
Refactor e2e-test utilities into separate file

### DIFF
--- a/packages/e2e-testing/__tests__/e2e-utils.ts
+++ b/packages/e2e-testing/__tests__/e2e-utils.ts
@@ -19,24 +19,19 @@ export function setupLogging(logFilePath: string): Logger {
   return logger;
 }
 
-let provider: providers.JsonRpcProvider;
-const mine6Blocks = () => _.range(6).forEach(() => provider?.send('evm_mine', []));
+export function mineNBlocks(provider: providers.JsonRpcProvider, n: number) {
+  return (): void => _.range(n).forEach(() => provider?.send('evm_mine', []));
+}
 
-export function setupContractMonitor(rpcEndpoint: string, ethAssetHolderAddress: string): Contract {
-  provider = new providers.JsonRpcProvider(rpcEndpoint);
-  const assetHolder = new Contract(
+export function makeEthAssetHolderContract(
+  provider: providers.JsonRpcProvider,
+  ethAssetHolderAddress: string
+): Contract {
+  return new Contract(
     ethAssetHolderAddress,
     ContractArtifacts.EthAssetHolderArtifact.abi,
     provider
   );
-  assetHolder.on('Deposited', mine6Blocks);
-  assetHolder.on('AllocationUpdated', mine6Blocks);
-  return assetHolder;
-}
-
-export function teardownContractMonitor(assetHolder: Contract): void {
-  assetHolder.off('Deposited', mine6Blocks);
-  assetHolder.off('AllocationUpdated', mine6Blocks);
 }
 
 export const getChannels = async (wallet: ChannelWallet): Promise<ChannelResult[]> =>

--- a/packages/e2e-testing/__tests__/e2e-utils.ts
+++ b/packages/e2e-testing/__tests__/e2e-utils.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as fs from 'fs';
+
+import axios, {AxiosResponse} from 'axios';
+import _ from 'lodash';
+import {Wallet as ChannelWallet} from '@statechannels/server-wallet';
+import {ChannelResult} from '@statechannels/client-api-schema';
+import {providers, Contract} from 'ethers';
+import {ContractArtifacts} from '@statechannels/nitro-protocol';
+import {BN, NULL_APP_DATA} from '@statechannels/wallet-core';
+import {Logger} from '@graphprotocol/common-ts';
+
+import {createTestLogger, generateAllocationIdAndKeys} from '../src/utils';
+
+export function setupLogging(logFilePath: string): Logger {
+  logFilePath && fs.existsSync(logFilePath) && fs.truncateSync(logFilePath);
+  const logger = createTestLogger(logFilePath);
+  (logger as any).level = 'debug';
+  return logger;
+}
+
+let provider: providers.JsonRpcProvider;
+const mine6Blocks = () => _.range(6).forEach(() => provider?.send('evm_mine', []));
+
+export function setupContractMonitor(rpcEndpoint: string, ethAssetHolderAddress: string): Contract {
+  provider = new providers.JsonRpcProvider(rpcEndpoint);
+  const assetHolder = new Contract(
+    ethAssetHolderAddress,
+    ContractArtifacts.EthAssetHolderArtifact.abi,
+    provider
+  );
+  assetHolder.on('Deposited', mine6Blocks);
+  assetHolder.on('AllocationUpdated', mine6Blocks);
+  return assetHolder;
+}
+
+export function teardownContractMonitor(assetHolder: Contract): void {
+  assetHolder.off('Deposited', mine6Blocks);
+  assetHolder.off('AllocationUpdated', mine6Blocks);
+}
+
+export const getChannels = async (wallet: ChannelWallet): Promise<ChannelResult[]> =>
+  (await wallet.getChannels()).channelResults.filter((c) => c.appData !== NULL_APP_DATA);
+
+// We know the destination of the second allocationItem will be the allocationId
+export const getChannelsForAllocations = (
+  channels: ChannelResult[],
+  allocationId: string
+): ChannelResult[] =>
+  channels.filter(({allocations}) =>
+    BN.eq(allocationId, allocations[0].allocationItems[1].destination)
+  );
+
+export const successfulPayment = (
+  payerServerUrl: string,
+  params?: {
+    privateKey?: string;
+    allocationId?: string;
+    expectPaymentNotReceived?: boolean;
+    expectReceiptNotReceived?: boolean;
+  }
+): Promise<AxiosResponse<{status: number}>> => {
+  const defaultParams = generateAllocationIdAndKeys(1)[0];
+  return axios.get(`${payerServerUrl}/sendPayment`, {params: _.merge(defaultParams, params)});
+};
+
+export const syncChannels = (payerServerUrl: string): Promise<{status: number}> =>
+  axios.get(`${payerServerUrl}/syncChannels`);

--- a/packages/e2e-testing/__tests__/e2e.test.ts
+++ b/packages/e2e-testing/__tests__/e2e.test.ts
@@ -1,22 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as fs from 'fs';
-
 import {configureEnvVariables, ETHERLIME_ACCOUNTS} from '@statechannels/devtools';
 import axios from 'axios';
-import _ from 'lodash';
 import {
   DBAdmin,
   overwriteConfigWithDatabaseConnection,
   Wallet as ChannelWallet,
   defaultTestConfig
 } from '@statechannels/server-wallet';
-import {ChannelResult} from '@statechannels/client-api-schema';
-import {BigNumber, providers, Contract} from 'ethers';
-import {ContractArtifacts} from '@statechannels/nitro-protocol';
-import {NULL_APP_DATA} from '@statechannels/wallet-core';
+import {Contract} from 'ethers';
 import {Logger} from '@graphprotocol/common-ts';
 
-import {clearExistingChannels, createTestLogger, generateAllocationIdAndKeys} from '../src/utils';
+import {clearExistingChannels, generateAllocationIdAndKeys} from '../src/utils';
 import {
   PAYER_SERVER_URL,
   RECEIPT_SERVER_DB_NAME,
@@ -27,23 +21,40 @@ import {
 } from '../src/constants';
 import {createPaymentServer, createReceiptServer} from '../src/external-server';
 
+import {
+  getChannels,
+  getChannelsForAllocations,
+  setupContractMonitor,
+  setupLogging,
+  successfulPayment,
+  syncChannels,
+  teardownContractMonitor
+} from './e2e-utils';
+
+configureEnvVariables();
+
 // Setup / Configuration
 jest.setTimeout(60_000);
+
 const NUM_ALLOCATIONS = 2;
-configureEnvVariables();
+
 const useLedger = process.env.USE_LEDGER || false;
 const useChain = process.env.FUNDING_STRATEGY === 'Direct';
 const LOG_FILE = `/tmp/e2e-test-${useLedger ? 'with-ledger' : 'without-ledger'}-${
   useChain ? 'with-chain' : 'without-chain'
 }.log`;
-const logFileArg = `--logFile ${LOG_FILE}`;
-const ledgerArg = `--useLedger ${useLedger}`;
-const fundingArg = `--fundingStrategy ${process.env.FUNDING_STRATEGY || 'Fake'}`;
-const threadingArg = `--amountOfWorkerThreads ${process.env.AMOUNT_OF_WORKER_THREADS || 0}`;
-const numAllocationsArg = `--numAllocations ${NUM_ALLOCATIONS}`;
-const serverArgs = [ledgerArg, logFileArg, fundingArg, threadingArg, numAllocationsArg];
+
+const serverArgs = [
+  `--useLedger ${useLedger}`,
+  `--logFile ${LOG_FILE}`,
+  `--fundingStrategy ${process.env.FUNDING_STRATEGY || 'Fake'}`,
+  `--amountOfWorkerThreads ${process.env.AMOUNT_OF_WORKER_THREADS || 0}`,
+  `--numAllocations ${NUM_ALLOCATIONS}`
+];
+
 const gatewayServer = createPaymentServer(serverArgs);
 const indexerServer = createReceiptServer(serverArgs);
+
 const baseConfig = defaultTestConfig({
   networkConfiguration: {
     chainNetworkID: process.env.CHAIN_ID
@@ -56,25 +67,34 @@ const baseConfig = defaultTestConfig({
     pk: ETHERLIME_ACCOUNTS[0].privateKey
   }
 });
+
 const payerConfig = overwriteConfigWithDatabaseConnection(baseConfig, {
   database: PAYER_SERVER_DB_NAME
 });
+
 const receiverConfig = overwriteConfigWithDatabaseConnection(baseConfig, {
   database: RECEIPT_SERVER_DB_NAME
 });
 
 // Setup / Teardown callbacks
 let logger: Logger;
-let provider: providers.JsonRpcProvider;
+
 let assetHolder: Contract;
 let paymentWallet: ChannelWallet;
 let receiptWallet: ChannelWallet;
 
 beforeAll(async () => {
-  setupLogging();
-  setupContractMonitor();
+  logger = setupLogging(LOG_FILE);
+
+  if (process.env.RPC_ENDPOINT /* chain-setup.ts */)
+    assetHolder = setupContractMonitor(
+      process.env.RPC_ENDPOINT,
+      process.env.ETH_ASSET_HOLDER_ADDRESS as string
+    );
+
   await DBAdmin.migrateDatabase(payerConfig);
   await DBAdmin.migrateDatabase(receiverConfig);
+
   paymentWallet = await ChannelWallet.create(payerConfig);
   receiptWallet = await ChannelWallet.create(receiverConfig);
 });
@@ -94,7 +114,8 @@ afterEach(async () => {
 });
 
 afterAll(async () => {
-  teardownContractMonitor();
+  if (process.env.RPC_ENDPOINT /* chain-setup.ts */) teardownContractMonitor(assetHolder);
+
   await paymentWallet.destroy();
   await receiptWallet.destroy();
 });
@@ -105,7 +126,7 @@ describe('Payment & Receipt Managers E2E', () => {
   test(`Can create and pay with ${NUM_ALLOCATIONS} allocations`, async () => {
     // Make 2 payments per allocation
     const allocations = generateAllocationIdAndKeys(NUM_ALLOCATIONS);
-    const promises = allocations.map(successfulPayment);
+    const promises = allocations.map(() => successfulPayment(PAYER_SERVER_URL));
 
     for (const {status, data} of await Promise.all(promises)) {
       expect(status).toBe(200);
@@ -116,8 +137,8 @@ describe('Payment & Receipt Managers E2E', () => {
         subgraphDeploymentID: TEST_SUBGRAPH_ID.toString()
       });
     }
-    const receiptChannels = await getChannels('receipt');
-    const paymentChannels = await getChannels('payment');
+    const receiptChannels = await getChannels(receiptWallet);
+    const paymentChannels = await getChannels(paymentWallet);
 
     for (const allocationId of allocations.map((a) => a.allocationId)) {
       const receiptChannelsForAllocation = getChannelsForAllocations(receiptChannels, allocationId);
@@ -126,52 +147,57 @@ describe('Payment & Receipt Managers E2E', () => {
 
       expect(receiptChannelsForAllocation).toHaveLength(NUM_ALLOCATIONS);
       expect(paymentChannelsForAllocation).toHaveLength(NUM_ALLOCATIONS);
-      expectChannelsHaveStatus(receiptChannelsForAllocation, 'running');
-      expectChannelsHaveStatus(paymentChannelsForAllocation, 'running');
+
+      for (const {status} of receiptChannelsForAllocation) expect(status).toBe('running');
+      for (const {status} of paymentChannelsForAllocation) expect(status).toBe('running');
     }
   });
 
   test(`Can remove ${NUM_ALLOCATIONS} allocations using syncAllocations`, async () => {
     await axios.post(`${PAYER_SERVER_URL}/syncAllocations`);
 
-    const receiptChannels = await getChannels('receipt');
-    const paymentChannels = await getChannels('payment');
+    const receiptChannels = await getChannels(receiptWallet);
+    const paymentChannels = await getChannels(paymentWallet);
 
-    expectChannelsHaveStatus(receiptChannels, 'closed');
-    expectChannelsHaveStatus(paymentChannels, 'closed');
+    for (const {status} of receiptChannels) expect(status).toBe('closed');
+    for (const {status} of paymentChannels) expect(status).toBe('closed');
   });
 
   test('Payment and Receipt can get back in sync if indexer offline', async () => {
     // The default number of channels per allocation is 2
-    const paymentNotReceived = () => successfulPayment({expectPaymentNotReceived: true});
+    const paymentNotReceived = () =>
+      successfulPayment(PAYER_SERVER_URL, {expectPaymentNotReceived: true});
 
     // Make one successful payment
-    await expect(successfulPayment()).resolves.toMatchObject({status: 200});
+    await expect(successfulPayment(PAYER_SERVER_URL)).resolves.toMatchObject({status: 200});
 
     // Make a payment, but never receive a reply
     await expect(paymentNotReceived()).rejects.toThrowError('Request failed with status code 500');
 
     // Make another successful payment (useable channels is now 1, down from 2)
-    await expect(successfulPayment()).resolves.toMatchObject({status: 200});
+    await expect(successfulPayment(PAYER_SERVER_URL)).resolves.toMatchObject({status: 200});
 
     // Make a payment, but never receive a reply
     await expect(paymentNotReceived()).rejects.toThrowError('Request failed with status code 500');
 
     // With no more channels available, payments start failing
-    await expect(successfulPayment()).rejects.toThrowError('Request failed with status code 406');
+    await expect(successfulPayment(PAYER_SERVER_URL)).rejects.toThrowError(
+      'Request failed with status code 406'
+    );
 
     // Call syncChannels (return to 2 good channels)
-    await expect(syncChannels()).resolves.toMatchObject({status: 200});
+    await expect(syncChannels(PAYER_SERVER_URL)).resolves.toMatchObject({status: 200});
 
     // Make a successful payment (to verify sync channels worked)
-    await expect(successfulPayment()).resolves.toMatchObject({status: 200});
+    await expect(successfulPayment(PAYER_SERVER_URL)).resolves.toMatchObject({status: 200});
   });
 
   test('Payment and Receipt can get back in sync if payer missed receipt', async () => {
-    const receiptNotReceived = () => successfulPayment({expectReceiptNotReceived: true});
+    const receiptNotReceived = () =>
+      successfulPayment(PAYER_SERVER_URL, {expectReceiptNotReceived: true});
 
     // Make one successful payment
-    await expect(successfulPayment()).resolves.toMatchObject({status: 200});
+    await expect(successfulPayment(PAYER_SERVER_URL)).resolves.toMatchObject({status: 200});
 
     // Make a payment, but discard the result (stalling 1 of 2 channels)
     await expect(receiptNotReceived()).rejects.toThrowError('Request failed with status code 500');
@@ -180,73 +206,14 @@ describe('Payment & Receipt Managers E2E', () => {
     await expect(receiptNotReceived()).rejects.toThrowError('Request failed with status code 500');
 
     // With no more channels available, payments start failing
-    await expect(successfulPayment()).rejects.toThrowError('Request failed with status code 406');
+    await expect(successfulPayment(PAYER_SERVER_URL)).rejects.toThrowError(
+      'Request failed with status code 406'
+    );
 
     // Call syncChannels (return to 2 good channels)
-    await expect(syncChannels()).resolves.toMatchObject({status: 200});
+    await expect(syncChannels(PAYER_SERVER_URL)).resolves.toMatchObject({status: 200});
 
     // Make a successful payment (to verify sync channels worked)
-    await expect(successfulPayment()).resolves.toMatchObject({status: 200});
+    await expect(successfulPayment(PAYER_SERVER_URL)).resolves.toMatchObject({status: 200});
   });
 });
-
-// Helpers
-
-function setupLogging() {
-  LOG_FILE && fs.existsSync(LOG_FILE) && fs.truncateSync(LOG_FILE);
-  logger = createTestLogger(LOG_FILE);
-  (logger as any).level = 'debug';
-}
-const mine6Blocks = () => _.range(6).forEach(() => provider?.send('evm_mine', []));
-
-function setupContractMonitor() {
-  if (process.env.RPC_ENDPOINT /* defined in chain-setup.ts */) {
-    provider = new providers.JsonRpcProvider(process.env.RPC_ENDPOINT);
-    assetHolder = new Contract(
-      process.env.ETH_ASSET_HOLDER_ADDRESS as string,
-      ContractArtifacts.EthAssetHolderArtifact.abi,
-      provider
-    );
-    assetHolder.on('Deposited', mine6Blocks);
-    assetHolder.on('AllocationUpdated', mine6Blocks);
-  }
-}
-
-function teardownContractMonitor() {
-  if (process.env.RPC_ENDPOINT /* defined in chain-setup.ts */) {
-    assetHolder.off('Deposited', mine6Blocks);
-    assetHolder.off('AllocationUpdated', mine6Blocks);
-  }
-}
-
-const getChannels = async (database: 'receipt' | 'payment') => {
-  const wallet = database === 'receipt' ? receiptWallet : paymentWallet;
-  // Filter out the ledger channels results
-  return (await wallet.getChannels()).channelResults.filter((c) => c.appData !== NULL_APP_DATA);
-};
-
-const expectChannelsHaveStatus = async (
-  channels: ChannelResult[],
-  status: 'running' | 'closed'
-) => {
-  for (const channel of channels) {
-    expect(channel).toMatchObject({status});
-  }
-};
-// We know the destination of the second allocationItem will be the allocationId
-const getChannelsForAllocations = (channels: ChannelResult[], allocationId: string) =>
-  channels.filter((c) =>
-    BigNumber.from(allocationId).eq(c.allocations[0].allocationItems[1].destination)
-  );
-
-const successfulPayment = (params?: {
-  privateKey?: string;
-  allocationId?: string;
-  expectPaymentNotReceived?: boolean;
-  expectReceiptNotReceived?: boolean;
-}) => {
-  const defaultParams = generateAllocationIdAndKeys(1)[0];
-
-  return axios.get(`${PAYER_SERVER_URL}/sendPayment`, {params: _.merge(defaultParams, params)});
-};
-const syncChannels = () => axios.get(`${PAYER_SERVER_URL}/syncChannels`);

--- a/packages/e2e-testing/package.json
+++ b/packages/e2e-testing/package.json
@@ -14,7 +14,7 @@
     "@types/eslint": "^7.2.3",
     "@types/eslint-plugin-prettier": "3.1.0",
     "@types/express": "^4.17.8",
-    "@types/jest": "26.0.4",
+    "@types/jest": "26.0.15",
     "@types/lodash": "^4.14.161",
     "@types/nodemon": "^1.19.0",
     "@types/pg": "^7.14.4",

--- a/packages/e2e-testing/tsconfig.json
+++ b/packages/e2e-testing/tsconfig.json
@@ -8,5 +8,5 @@
     "noImplicitAny": true
   },
   "references": [{"path": "../payments"},{"path": "../receipts"}],
-  "include": ["src", "e2e-test"]
+  "include": ["src", "__tests__"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,6 +2615,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@26.0.15", "@types/jest@26.x":
+  version "26.0.15"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-26.0.15.tgz#12e02c0372ad0548e07b9f4e19132b834cb1effe"
+  integrity sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/jest@26.0.4":
   version "26.0.4"
   resolved "https://registry.npmjs.org/@types/jest/-/jest-26.0.4.tgz#d2e513e85aca16992816f192582b5e67b0b15efb"
@@ -2622,14 +2630,6 @@
   dependencies:
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
-
-"@types/jest@26.x":
-  version "26.0.15"
-  resolved "https://registry.npmjs.org/@types/jest/-/jest-26.0.15.tgz#12e02c0372ad0548e07b9f4e19132b834cb1effe"
-  integrity sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==
-  dependencies:
-    jest-diff "^26.0.0"
-    pretty-format "^26.0.0"
 
 "@types/jest@^25.2.1":
   version "25.2.3"


### PR DESCRIPTION
This is a fairly straightforward change that I don't think warrants the full usage of the pull request template. Basically, this refactors out some utility methods out of `e2e.test.ts` into a new file, `e2e-utils.ts` which is then imported from. This is in preparation of other end-to-end tests that will reuse these utilities.
