### PR TITLE
Use ensureObjectives

### DIFF
--- a/packages/e2e-testing/src/payment-server.ts
+++ b/packages/e2e-testing/src/payment-server.ts
@@ -169,7 +169,11 @@ const createTasks = (logger: Logger) => ({
           provider: process.env.RPC_ENDPOINT,
           pk: ETHERLIME_ACCOUNTS[0].privateKey
         }
-      })
+      }),
+      backoffStrategy: {
+        numAttempts: 1,
+        initialDelay: 50
+      }
     });
 
     const testAllocations = generateAllocations(numAllocations);

--- a/packages/payments/src/__tests__/fake-indexer.ts
+++ b/packages/payments/src/__tests__/fake-indexer.ts
@@ -200,7 +200,9 @@ export class FakeIndexer {
     return serializeState(signedState);
   }
 
-  public goOffline(): void {
+  private numMessagesToThrow = -1;
+  public goOffline(forNMessages = -1): void {
+    this.numMessagesToThrow = forNMessages;
     this.logger?.debug(`FakeIndexer offline`);
     this.online = false;
   }
@@ -208,10 +210,18 @@ export class FakeIndexer {
   public goOnline(): void {
     this.logger?.debug(`FakeIndexer online`);
     this.online = true;
+    this.numMessagesToThrow = -1;
   }
 
   private throwIfOffline() {
-    if (!this.online) throw new Error('FakeIndexer is offline');
+    if (this.numMessagesToThrow === 0) {
+      this.goOnline();
+    }
+
+    if (!this.online) {
+      this.numMessagesToThrow -= 1;
+      throw new Error(`FakeIndexer is offline for ${this.numMessagesToThrow} more messages`);
+    }
   }
 
   public block(): void {

--- a/packages/payments/src/__tests__/payment-manager.test.ts
+++ b/packages/payments/src/__tests__/payment-manager.test.ts
@@ -271,7 +271,8 @@ describe('ChannelManager', () => {
     await channelManager.syncAllocations([request(fakeIndexer.allocation(allocationId))]);
     expect(await channelManager.activeChannelCount(allocationId)).toEqual(0);
 
-    fakeIndexer.goOnline();
+    // Test that ensureObjective works when one outgoing message is dropped
+    fakeIndexer.goOffline(1);
     const paymentManager = await TestPaymentManager.create({
       walletConfig,
       logger,

--- a/packages/payments/src/__tests__/payment-manager.test.ts
+++ b/packages/payments/src/__tests__/payment-manager.test.ts
@@ -270,6 +270,7 @@ describe('ChannelManager', () => {
     // sync allocations
     await channelManager.syncAllocations([request(fakeIndexer.allocation(allocationId))]);
     expect(await channelManager.activeChannelCount(allocationId)).toEqual(0);
+    // expect(channelManager.wallet.listenerCount('objectiveSucceeded')).toEqual(0);
 
     // Test that ensureObjective works when one outgoing message is dropped
     fakeIndexer.goOffline(1);
@@ -287,6 +288,7 @@ describe('ChannelManager', () => {
     const channelManager2 = await TestChannelManager.create({...cmDefaultOpts, messageSender});
     expect((await paymentWallet.getChannels()).channelResults).toHaveLength(2);
     await channelManager2.syncAllocations([request(fakeIndexer.allocation(allocationId))]);
+    expect(channelManager2.wallet.listenerCount('objectiveSucceeded')).toEqual(0);
 
     // check it has created the correct payers
     expect(await channelManager2.activeChannelCount(allocationId)).toEqual(2);

--- a/packages/payments/src/__tests__/payment-manager.test.ts
+++ b/packages/payments/src/__tests__/payment-manager.test.ts
@@ -270,7 +270,7 @@ describe('ChannelManager', () => {
     // sync allocations
     await channelManager.syncAllocations([request(fakeIndexer.allocation(allocationId))]);
     expect(await channelManager.activeChannelCount(allocationId)).toEqual(0);
-    // expect(channelManager.wallet.listenerCount('objectiveSucceeded')).toEqual(0);
+    expect(channelManager.wallet.listenerCount('objectiveSucceeded')).toEqual(0);
 
     // Test that ensureObjective works when one outgoing message is dropped
     fakeIndexer.goOffline(1);

--- a/packages/payments/src/__tests__/payment-manager.test.ts
+++ b/packages/payments/src/__tests__/payment-manager.test.ts
@@ -62,6 +62,7 @@ const cmDefaultOpts: Pick<
   | 'fundsPerAllocation'
   | 'walletConfig'
   | 'cache'
+  | 'backoffStrategy'
 > = {
   logger,
   contracts: mockContracts,
@@ -69,7 +70,11 @@ const cmDefaultOpts: Pick<
   paymentChannelFundingAmount: BN.from(1_000_000_000),
   fundsPerAllocation: BN.from(1_000_000_000_000),
   walletConfig,
-  cache
+  cache,
+  backoffStrategy: {
+    initialDelay: 50,
+    numAttempts: 1
+  }
 };
 
 type MessageSender = ChannelManagerOptions['messageSender'];

--- a/packages/payments/src/__tests__/test-channel-manager.ts
+++ b/packages/payments/src/__tests__/test-channel-manager.ts
@@ -11,7 +11,7 @@ export class TestChannelManager extends ChannelManager {
     const ret = await this.cache.getLedgerChannels(allocationId);
     return ret.length > 0;
   }
-  constructor(wallet: Wallet, opts: ChannelManagerOptions) {
+  constructor(public wallet: Wallet, opts: ChannelManagerOptions) {
     super(wallet, opts);
   }
   static async create(opts: ChannelManagerOptions): Promise<TestChannelManager> {

--- a/packages/payments/src/channel-manager.ts
+++ b/packages/payments/src/channel-manager.ts
@@ -452,6 +452,7 @@ export class ChannelManager implements ChannelManagementAPI {
       newResults.map((c) => latestResult.set(c.channelId, c));
     }
 
+    this.wallet.removeListener('objectiveSucceeded', onObjectiveSucceded);
     this.logger.error('Unable to ensure objectives', {remaining: Array.from(remaining.keys())});
     throw new Error('Unable to ensure objectives');
   }

--- a/packages/payments/src/channel-manager.ts
+++ b/packages/payments/src/channel-manager.ts
@@ -426,13 +426,13 @@ export class ChannelManager implements ChannelManagementAPI {
   ): Promise<ChannelResult[]> {
     const remaining = new Map(objectives.map((o) => [o.objectiveId, o]));
 
-    objectives.map(({objectiveId}) =>
-      this.wallet.on('objectiveSucceeded', (o) => {
-        if (o.objectiveId === objectiveId) {
-          remaining.delete(objectiveId);
-        }
-      })
-    );
+    const onObjectiveSucceded = (o: DBObjective) => {
+      if (o.objectiveId === o.objectiveId) {
+        remaining.delete(o.objectiveId);
+      }
+    };
+
+    this.wallet.on('objectiveSucceeded', onObjectiveSucceded);
 
     const results = await this.exchangeMessagesUntilOutboxIsEmpty(initialMessage);
     const latestResult = new Map(results.map((c) => [c.channelId, c]));

--- a/packages/payments/src/channel-manager.ts
+++ b/packages/payments/src/channel-manager.ts
@@ -430,6 +430,10 @@ export class ChannelManager implements ChannelManagementAPI {
       if (o.objectiveId === o.objectiveId) {
         remaining.delete(o.objectiveId);
       }
+
+      if (remaining.size === 0) {
+        this.wallet.removeListener('objectiveSucceeded', onObjectiveSucceded);
+      }
     };
 
     this.wallet.on('objectiveSucceeded', onObjectiveSucceded);

--- a/packages/payments/src/channel-manager.ts
+++ b/packages/payments/src/channel-manager.ts
@@ -448,6 +448,7 @@ export class ChannelManager implements ChannelManagementAPI {
       newResults.map((c) => latestResult.set(c.channelId, c));
     }
 
+    this.logger.error('Unable to ensure objectives', {remaining: Array.from(remaining.keys())});
     throw new Error('Unable to ensure objectives');
   }
 

--- a/packages/payments/src/channel-manager.ts
+++ b/packages/payments/src/channel-manager.ts
@@ -102,7 +102,7 @@ export type ChannelManagementAPI = {
 
 export class ChannelManager implements ChannelManagementAPI {
   private logger: Logger;
-  private wallet: ChannelWallet;
+  protected wallet: ChannelWallet;
   private destinationAddress: string;
   protected cache: ChannelCache;
   private fundsPerAllocation: Uint256;

--- a/packages/payments/src/channel-manager.ts
+++ b/packages/payments/src/channel-manager.ts
@@ -696,6 +696,11 @@ export class ChannelManager implements ChannelManagementAPI {
 
       const {channelResults, outbox} = await this.wallet.createChannels(startState, numChannels);
 
+      if (outbox.length !== 1) {
+        this.logger.error('Unexpected outbox length, expected 1', {channelsToCreate, outbox});
+        throw new Error('Unexpected outbox length, expected 1');
+      }
+
       const channelIds = _.map(channelResults, 'channelId');
 
       this.channelInsights.post(


### PR DESCRIPTION
# Description
Introduces ensureObjectives function, which is used when opening channels to ensure that they do get opened before `ensureAllocation` resolves.

This is progress towards #7. I decided to first use objectives for opening channels, rather than closing channels, since we had already implemented `ensureChannelsOpen`. So, this was a mostly cut-and-paste affair, that can then be re-used for concluding channels.

Blocked by https://github.com/statechannels/statechannels/issues/3262.

## [Optional] Changes
1. A `backoffStrategy` is introduced to the `ChannelManager` . One use of this is to configure the tests so that `ensureAllocation` rejects within a reasonable time.
2. `fakeIndexer` is configured to go offline for some number of messages. This allows us to test `ensureAllocations` in the presence of _certain_ (not all) network errors.
3. The `wallet` property of the `ChannelManager` is protected, and is overwritten by a `public wallet` property of the `TestChannelManager`. This allow us to assert in tests that we've properly cleaned up event listeners.

# Checklist:
- [x] All items are checked