### PR TITLE
Add network errors to ledger funding integration test

### DIFF
--- a/packages/e2e-testing/__tests__/bad-network.test.ts
+++ b/packages/e2e-testing/__tests__/bad-network.test.ts
@@ -1,0 +1,133 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import {configureEnvVariables} from '@statechannels/devtools';
+import _ from 'lodash';
+import {
+  DBAdmin,
+  overwriteConfigWithDatabaseConnection,
+  Wallet as ChannelWallet,
+  defaultTestConfig
+} from '@statechannels/server-wallet';
+import {Logger} from '@graphprotocol/common-ts';
+
+import {clearExistingChannels, generateAllocationIdAndKeys} from '../src/utils';
+import {RECEIPT_SERVER_DB_NAME, PAYER_SERVER_DB_NAME, PAYER_SERVER_URL} from '../src/constants';
+import {createPaymentServer, createReceiptServer} from '../src/external-server';
+
+import {
+  getChannels,
+  getChannelsForAllocations,
+  setupLogging,
+  successfulPayment,
+  syncChannels
+} from './e2e-utils';
+
+// Setup / Configuration
+jest.setTimeout(100_000);
+
+configureEnvVariables();
+
+const LOG_FILE = `/tmp/bad-network-test-without-chain.log`;
+
+const serverArgs = [
+  `--amountOfWorkerThreads ${process.env.AMOUNT_OF_WORKER_THREADS || 0}`,
+  `--channelsPerAllocation 5`,
+  `--dropIncomingRate 0.03`, // 3% chance incoming messages are dropped
+  `--dropOutgoingRate 0.03`, // 3% chance outgoing messages are dropped
+  `--fundingStrategy Fake`,
+  `--logFile ${LOG_FILE}`,
+  `--meanDelay 15`, // Mean 15ms delay between message send and receive (distribution)
+  `--numAllocations 5`,
+  `--useLedger true`
+];
+
+const gatewayServer = createPaymentServer(serverArgs);
+const indexerServer = createReceiptServer(serverArgs);
+
+const baseConfig = defaultTestConfig({
+  networkConfiguration: {
+    chainNetworkID: process.env.CHAIN_ID
+      ? parseInt(process.env.CHAIN_ID)
+      : defaultTestConfig().networkConfiguration.chainNetworkID
+  },
+  chainServiceConfiguration: {
+    attachChainService: false
+  }
+});
+
+const payerConfig = overwriteConfigWithDatabaseConnection(baseConfig, {
+  database: PAYER_SERVER_DB_NAME
+});
+
+const receiverConfig = overwriteConfigWithDatabaseConnection(baseConfig, {
+  database: RECEIPT_SERVER_DB_NAME
+});
+
+// Setup / Teardown callbacks
+let logger: Logger;
+let paymentWallet: ChannelWallet;
+let receiptWallet: ChannelWallet;
+
+beforeAll(async () => {
+  logger = setupLogging(LOG_FILE);
+  await DBAdmin.migrateDatabase(payerConfig);
+  await DBAdmin.migrateDatabase(receiverConfig);
+  paymentWallet = await ChannelWallet.create(payerConfig);
+  receiptWallet = await ChannelWallet.create(receiverConfig);
+});
+
+beforeEach(async () => {
+  try {
+    await Promise.all([RECEIPT_SERVER_DB_NAME, PAYER_SERVER_DB_NAME].map(clearExistingChannels));
+    await Promise.all([gatewayServer.start(logger), indexerServer.start(logger)]);
+  } catch (error) {
+    logger.error(error);
+    process.exit(1);
+  }
+});
+
+afterEach(async () => {
+  await Promise.all([gatewayServer.stop(), indexerServer.stop()]);
+});
+
+afterAll(async () => {
+  await paymentWallet.destroy();
+  await receiptWallet.destroy();
+});
+
+describe('Payment & Receipt Managers E2E', () => {
+  test.only(`Can create channels and make 20 payments`, async () => {
+    const allocations = generateAllocationIdAndKeys(5);
+
+    const receiptChannels = await getChannels(receiptWallet);
+    const paymentChannels = await getChannels(paymentWallet);
+
+    for (const allocationId of _.map(allocations, 'allocationId')) {
+      const receiptChannelsForAllocation = getChannelsForAllocations(receiptChannels, allocationId);
+
+      const paymentChannelsForAllocation = getChannelsForAllocations(paymentChannels, allocationId);
+
+      expect(receiptChannelsForAllocation).toHaveLength(5);
+      expect(paymentChannelsForAllocation).toHaveLength(5);
+
+      for (const {status} of receiptChannelsForAllocation) expect(status).toBe('running');
+      for (const {status} of paymentChannelsForAllocation) expect(status).toBe('running');
+    }
+
+    // Can then make payments
+    let numPayments = 0;
+
+    while (numPayments < 20) {
+      // try {
+      await syncChannels(PAYER_SERVER_URL);
+      const {status} = await successfulPayment(PAYER_SERVER_URL);
+      if (status === 200) numPayments++;
+      // } catch (err) {
+      //   logger.trace('Payment failed', {err});
+      //   continue;
+      // }
+    }
+
+    expect(numPayments).toBeGreaterThanOrEqual(20);
+  });
+});

--- a/packages/e2e-testing/__tests__/bad-network.test.ts
+++ b/packages/e2e-testing/__tests__/bad-network.test.ts
@@ -109,20 +109,14 @@ describe('Payment & Receipt Managers E2E', () => {
     await syncAllocations(PAYER_SERVER_URL, {
       requests: allocations.map((allocation) => ({
         allocation: {
+          ...allocation,
           id: allocation.id,
-          indexer: {
-            id: allocation.indexer.id,
-            url: allocation.indexer.url,
-            stakedTokens: allocation.indexer.stakedTokens
-          },
           subgraphDeploymentID: {
             ...allocation.subgraphDeploymentID,
-            display: allocation.subgraphDeploymentID.display,
-            ipfsHash: allocation.subgraphDeploymentID.ipfsHash,
-            bytes32: allocation.subgraphDeploymentID.bytes32
-          },
-          allocatedTokens: allocation.allocatedTokens,
-          createdAtEpoch: allocation.createdAtEpoch
+            display: allocation.subgraphDeploymentID.display, // getter
+            ipfsHash: allocation.subgraphDeploymentID.ipfsHash, // getter
+            bytes32: allocation.subgraphDeploymentID.bytes32 // getter
+          }
         },
         num: NUM_ALLOCATIONS,
         type: 'SetTo'

--- a/packages/e2e-testing/__tests__/bad-network.test.ts
+++ b/packages/e2e-testing/__tests__/bad-network.test.ts
@@ -110,9 +110,10 @@ describe('Payment & Receipt Managers E2E', () => {
       requests: allocations.map((allocation) => ({
         allocation: {
           ...allocation,
-          id: allocation.id,
           subgraphDeploymentID: {
             ...allocation.subgraphDeploymentID,
+            // The next three properties are getters on the SubgraphDeploymentID type
+            // and thus are serialized explicitly here to be sent over the HTTP req
             display: allocation.subgraphDeploymentID.display, // getter
             ipfsHash: allocation.subgraphDeploymentID.ipfsHash, // getter
             bytes32: allocation.subgraphDeploymentID.bytes32 // getter

--- a/packages/e2e-testing/__tests__/bad-network.test.ts
+++ b/packages/e2e-testing/__tests__/bad-network.test.ts
@@ -103,7 +103,7 @@ afterAll(async () => {
 });
 
 describe('Payment & Receipt Managers E2E', () => {
-  test.only(`Can create channels and make 20 payments`, async () => {
+  test(`Can create channels and make 20 payments`, async () => {
     const allocations = generateAllocations(NUM_ALLOCATIONS);
 
     await syncAllocations(PAYER_SERVER_URL, {

--- a/packages/e2e-testing/__tests__/bad-network.test.ts
+++ b/packages/e2e-testing/__tests__/bad-network.test.ts
@@ -36,7 +36,7 @@ const serverArgs = [
   `--amountOfWorkerThreads ${process.env.AMOUNT_OF_WORKER_THREADS || 0}`,
   `--channelsPerAllocation 5`,
   `--dropIncomingRate 0.03`, // 3% chance incoming messages are dropped
-  `--dropOutgoingRate 0.03`, // 3% chance outgoing messages are dropped
+  `--dropOutgoingRate 0`, // 0% chance outgoing messages are dropped
   `--fundingStrategy Fake`,
   `--logFile ${LOG_FILE}`,
   `--meanDelay 15`, // Mean 15ms delay between message send and receive (distribution)

--- a/packages/e2e-testing/__tests__/bad-network.test.ts
+++ b/packages/e2e-testing/__tests__/bad-network.test.ts
@@ -142,14 +142,9 @@ describe('Payment & Receipt Managers E2E', () => {
     let numPayments = 0;
 
     while (numPayments < 20) {
-      try {
-        await syncChannels(PAYER_SERVER_URL);
-        const {status} = await successfulPayment(PAYER_SERVER_URL);
-        if (status === 200) numPayments++;
-      } catch (err) {
-        if (err.toString() === 'Request failed with status code 500') continue;
-        throw err;
-      }
+      await syncChannels(PAYER_SERVER_URL);
+      const {status} = await successfulPayment(PAYER_SERVER_URL);
+      if (status === 200) numPayments++;
     }
 
     expect(numPayments).toBeGreaterThanOrEqual(20);

--- a/packages/e2e-testing/__tests__/e2e-utils.ts
+++ b/packages/e2e-testing/__tests__/e2e-utils.ts
@@ -9,6 +9,7 @@ import {providers, Contract} from 'ethers';
 import {ContractArtifacts} from '@statechannels/nitro-protocol';
 import {BN, NULL_APP_DATA} from '@statechannels/wallet-core';
 import {Logger} from '@graphprotocol/common-ts';
+import {EnsureAllocationRequest} from '@graphprotocol/payments/src/channel-manager';
 
 import {createTestLogger, generateAllocationIdAndKeys} from '../src/utils';
 
@@ -61,3 +62,10 @@ export const successfulPayment = (
 
 export const syncChannels = (payerServerUrl: string): Promise<{status: number}> =>
   axios.get(`${payerServerUrl}/syncChannels`);
+
+export const syncAllocations = (
+  payerServerUrl: string,
+  params?: {
+    requests: EnsureAllocationRequest[];
+  }
+): Promise<{status: number}> => axios.post(`${payerServerUrl}/syncAllocations`, params);

--- a/packages/e2e-testing/package.json
+++ b/packages/e2e-testing/package.json
@@ -56,6 +56,7 @@
     "test": "yarn test:e2e",
     "test:e2e:chain": "FUNDING_STRATEGY=Direct jest -c ./jest.chain.config.js e2e.test.ts --ci --runInBand",
     "test:e2e": "FUNDING_STRATEGY=Fake jest e2e.test.ts --ci --runInBand",
+    "test:badnetwork": "FUNDING_STRATEGY=Fake jest bad-network.test.ts --ci --runInBand",
     "test:stress:chain": "FUNDING_STRATEGY=Direct jest -c ./jest.chain.config.js stress.test.ts --ci",
     "test:stress": "FUNDING_STRATEGY=Fake jest stress.test.ts --ci",
     "lint:check": "eslint . --ext .ts --cache",

--- a/packages/e2e-testing/src/payment-server.ts
+++ b/packages/e2e-testing/src/payment-server.ts
@@ -304,14 +304,22 @@ function startApp(
           indexer: joi
             .object({
               url: joi.string().required(),
-              id: joi.string().required()
+              id: joi.string().required(),
+              stakedTokens: joi.object().required(),
+              createdAt: joi.number().optional()
             })
             .required(),
           subgraphDeploymentID: joi
             .object({
-              bytes32: joi.string().required()
+              display: joi.object().optional(),
+              ipfsHash: joi.string().optional(),
+              bytes32: joi.string().required(),
+              value: joi.string().required(),
+              kind: joi.equal('deployment-id')
             })
-            .required()
+            .required(),
+          allocatedTokens: joi.object().required(),
+          createdAtEpoch: joi.number().required()
         })
         .required(),
       type: joi.string().required(),

--- a/packages/e2e-testing/src/payment-server.ts
+++ b/packages/e2e-testing/src/payment-server.ts
@@ -177,9 +177,11 @@ const createTasks = (logger: Logger) => ({
     logger.info('Setting up channels for allocations', {
       allocationIds: testAllocations.map((x) => x.id)
     });
+
     await channelManager.ensureAllocations(
       testAllocations.map((allocation) => ({allocation, num: channelsPerAllocation, type: 'SetTo'}))
     );
+
     logger.info('Channels set up', {
       allocationIds: testAllocations.map((x) => x.id)
     });

--- a/packages/payments/src/channel-manager.ts
+++ b/packages/payments/src/channel-manager.ts
@@ -426,6 +426,11 @@ export class ChannelManager implements ChannelManagementAPI {
 
       if (_.values(notRunning).length === 0) return _.values(running);
 
+      this.logger.debug('Channels not yet opened, will try syncing after a timeout', {
+        notRunningChannelIds: _.map(notRunning, 'channelId'),
+        retryTimeoutMs
+      });
+
       await delay(retryTimeoutMs);
 
       results = await this._syncChannels(_.keys(notRunning));


### PR DESCRIPTION
**Add an end-to-end test with network errors**

This PR introduces a new end to end test file in `e2e-testing` which has networking errors built in. The hard-coded parameters in the pull request are:

- `--dropIncomingRate 0.03`: 3% chance incoming messages are dropped
-  `--dropOutgoingRate 0`: 0% chance outgoing messages are dropped
- `--meanDelay 15`: Mean 15ms delay between message send and receive (distribution)

Re-using existing utilities, the test will create 5 allocations with 5 channels each with the above failure rates during the messages exchanged between the parties. The `ensureChannelsOpen` method that was recently added is tested by this test as you can see in the logs... like this:

```
[1612888676159] DEBUG	(17644 on lhmbp13.local): Channels not yet opened, will try syncing after a timeout
    module: "PaymentManager"
    component: "ChannelPaymentManager"
    notRunningChannelIds: [
      "0xe81d7b12bf7dd64a59114a92660c7695408c20d31a9fadf6e4cf33d904e80421",
      "0xce146552223b2965311a034c0c893cedfa7bf49dc4d6999a460548acb3aaeafe",
      "0x87c204caaa7f718ad210dd58ee6f3c439fea74dd00a69613aa19ff9bc3eb16f0",
      "0x6223be1ba7fd3bba1cfb959bdc3c8bed14b59a53342c61aa81635a8d0de5441c",
      "0x069ed922b2853aa921a2ea395f6c7c54dbd587c63283b8556d44aaf85f37135e"
    ]
    retryTimeoutMs: 2000
```

This is a reasonably simple test. It creates the channels, and then attempts to make 20 payments, ignoring any errors. The goal is simply to ensure that _eventually_ if we try enough times, we will see 20 payments go through even in bad network conditions.

## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [x] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to relevant issues
- [x] I have added dependent tickets
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline
