### PR TITLE
Log system stats in e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,29 @@ restore_dep: &restore_dep
     key: v0-dependency-cache-{{ checksum "yarn.lock" }}
 
 commands:
+  log_stats:
+    description: 'Log stats '
+    parameters:
+      file:
+        type: string
+        default: stats
+    steps:
+      - run:
+          command: bash bin/log_memory.sh <<parameters.file>>
+          background: true
+
+  upload_logs:
+    description: 'Upload logs '
+    parameters:
+      file:
+        type: string
+        default: memory-usage.txt
+    steps:
+      - store_artifacts:
+          path: /root/<< parameters.file >>.txt
+          destination: << parameters.file >>
+
+
   install_postgresql_client:
     description: 'Install postgresql client'
     steps:
@@ -136,6 +159,8 @@ jobs:
 
     steps:
       - checkout
+      - log_stats:
+          file: e2e-stats
       - attach_workspace:
           at: ~/project
       - install_postgresql_client
@@ -155,6 +180,8 @@ jobs:
           path: /tmp/e2e-test-with-ledger-without-chain.log
       - store_artifacts:
           path: /tmp/e2e-test-without-ledger-without-chain.log
+      - upload_logs:
+          file: e2e-stats
 
   stress-test:
     docker:

--- a/bin/log_memory.sh
+++ b/bin/log_memory.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+FILE=/home/circleci/$1.txt
+USAGE=/sys/fs/cgroup/memory/memory.usage_in_bytes
+MAX_USAGE=/sys/fs/cgroup/memory/memory.max_usage_in_bytes
+COUNTER=0
+
+# NB: The %mem field in the output of `ps afu` is incorrect, as it divides by the memory
+# avaiable to the whole system.
+# It seems like containers have about 70 gB of memory, so 1% usage corresponds to ~700 mB.
+# You can validate this assumption by checking the System MemTotal on line 1 of $FILE.
+echo "System $(grep MemTotal /proc/meminfo )" >> $FILE
+
+while true; do
+  {
+    echo "${COUNTER} ----------";
+    echo "Current Memory: $(($(cat $USAGE) / 1000000)) mB";
+    echo "Max Memory:     $(($(cat $MAX_USAGE) / 1000000)) mB";
+    ps afu;
+  } >> $FILE
+  sleep 1;
+  COUNTER=$((COUNTER + 1));
+done 

--- a/bin/log_memory.sh
+++ b/bin/log_memory.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FILE=/home/circleci/$1.txt
+FILE=/root/$1.txt
 USAGE=/sys/fs/cgroup/memory/memory.usage_in_bytes
 MAX_USAGE=/sys/fs/cgroup/memory/memory.max_usage_in_bytes
 COUNTER=0


### PR DESCRIPTION
Copies log_memory.sh from https://github.com/statechannels/statechannels/blob/7e2cd1de390aa76e4eca8a278a1bf1c20d1a5d70/bin/log_memory.sh,
with a small modification to account for an (unknown) difference 

The reason for adding this now, and specifically for the e2e tests, is, I am trying to debug why the e2e tests fail after installing
`@statechannels/latest`:
https://app.circleci.com/pipelines/github/statechannels/graph-payments/128/workflows/0eee8972-37d2-4d90-87ef-8fee89f715fc/jobs/845

I would like to compare the logged stats there to the logged stats on `main`, where the e2e tests pass.

_I think this is a legitimate addition to the codebase in its own right, in spite of its primary purpose._

### [Optional] How Has This Been Tested?

- [x] I found the stats logged in this PR's [CircleCI run](https://app.circleci.com/pipelines/github/statechannels/graph-payments/130/workflows/067fdee3-ec42-4303-9bbc-723f9ac52822/jobs/861/artifacts).

# Checklist:

## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to relevant issues
- [x] I have added dependent tickets
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline