### PR TITLE
Use Chain ID from process.env in E2E tests

### DIFF
--- a/packages/e2e-testing/__tests__/bad-network.test.ts
+++ b/packages/e2e-testing/__tests__/bad-network.test.ts
@@ -50,13 +50,7 @@ const indexerServer = createReceiptServer([
   // keys for attestation signing but no action is taken on startup
   `--numAllocations ${NUM_ALLOCATIONS}`
 ]);
-
 const baseConfig = defaultTestConfig({
-  networkConfiguration: {
-    chainNetworkID: process.env.CHAIN_ID
-      ? parseInt(process.env.CHAIN_ID)
-      : defaultTestConfig().networkConfiguration.chainNetworkID
-  },
   chainServiceConfiguration: {
     attachChainService: false
   }

--- a/packages/e2e-testing/__tests__/e2e.test.ts
+++ b/packages/e2e-testing/__tests__/e2e.test.ts
@@ -17,7 +17,8 @@ import {
   PAYER_SERVER_DB_NAME,
   REQUEST_CID,
   RESPONSE_CID,
-  TEST_SUBGRAPH_ID
+  TEST_SUBGRAPH_ID,
+  CHAIN_ID
 } from '../src/constants';
 import {createPaymentServer, createReceiptServer} from '../src/external-server';
 
@@ -55,18 +56,18 @@ const serverArgs = [
 const gatewayServer = createPaymentServer(serverArgs);
 const indexerServer = createReceiptServer(serverArgs);
 
-const baseConfig = defaultTestConfig({
-  networkConfiguration: {
-    chainNetworkID: process.env.CHAIN_ID
-      ? parseInt(process.env.CHAIN_ID)
-      : defaultTestConfig().networkConfiguration.chainNetworkID
-  },
-  chainServiceConfiguration: {
-    attachChainService: useChain,
-    provider: process.env.RPC_ENDPOINT,
-    pk: ETHERLIME_ACCOUNTS[0].privateKey
-  }
-});
+const baseConfig = {
+  ...defaultTestConfig({
+    chainServiceConfiguration: {
+      attachChainService: useChain,
+      provider: process.env.RPC_ENDPOINT,
+      pk: ETHERLIME_ACCOUNTS[0].privateKey
+    },
+    networkConfiguration: {
+      chainNetworkID: CHAIN_ID
+    }
+  })
+};
 
 const payerConfig = overwriteConfigWithDatabaseConnection(baseConfig, {
   database: PAYER_SERVER_DB_NAME

--- a/packages/e2e-testing/chain-setup.ts
+++ b/packages/e2e-testing/chain-setup.ts
@@ -3,33 +3,40 @@ import {ETHERLIME_ACCOUNTS, GanacheServer} from '@statechannels/devtools';
 import {utils} from 'ethers';
 import {deploy as deployNitro} from '@statechannels/server-wallet/lib/deployment/deploy';
 import {deploy as deployGraph} from '@graphprotocol/statechannels-contracts/deployment/deploy';
-import _ from 'lodash';
 
 export default async function setup(): Promise<void> {
+  if (process.env.CHAIN_NETWORK_ID) {
+    console.log(
+      `CHAIN_NETWORK_ID defined as ${process.env.CHAIN_NETWORK_ID}. Assuming chain env vars are set by caller`
+    );
+    return;
+  }
+
+  process.env['CHAIN_NETWORK_ID'] = '9002';
   process.env['GANACHE_HOST'] = '0.0.0.0';
   process.env['GANACHE_PORT'] = '8545';
   process.env[
     'RPC_ENDPOINT'
   ] = `http://${process.env['GANACHE_HOST']}:${process.env['GANACHE_PORT']}`;
-
   const ethPerAccount = utils.parseEther('100').toString();
   const etherlimeAccounts = ETHERLIME_ACCOUNTS.map((account) => ({
     ...account,
     amount: ethPerAccount
   }));
-  const defaultServerWalletAccount = {
-    privateKey: process.env.ETHEREUM_PRIVATE_KEY // useful if using rinkeby account for example
-      ? process.env.ETHEREUM_PRIVATE_KEY
-      : ETHERLIME_ACCOUNTS[0].privateKey,
-    amount: ethPerAccount
-  };
-  const accounts = _.unionBy(etherlimeAccounts, [defaultServerWalletAccount], 'privateKey');
 
   if (!process.env.GANACHE_PORT) {
     throw new Error('process.env.GANACHE_PORT must be defined');
   }
-  const ganacheServer = new GanacheServer(parseInt(process.env.GANACHE_PORT), 1337, accounts);
+  const ganacheServer = new GanacheServer(
+    parseInt(process.env.GANACHE_PORT),
+    Number(process.env.CHAIN_NETWORK_ID),
+    etherlimeAccounts,
+    10_000, // timeout
+    10_00_000_000, // gasLimit
+    1 // gasPrice
+  );
   await ganacheServer.ready();
+
   const deployedNitroArtifacts = await deployNitro();
   const deployedAttestationApp = await deployGraph();
 

--- a/packages/e2e-testing/src/constants.ts
+++ b/packages/e2e-testing/src/constants.ts
@@ -1,5 +1,5 @@
 import {SubgraphDeploymentID} from '@graphprotocol/common-ts';
-import {BigNumber, constants, utils} from 'ethers';
+import {constants, utils} from 'ethers';
 import * as base58 from 'bs58';
 import {defaultTestConfig} from '@statechannels/server-wallet';
 export const RECEIPT_SERVER_PORT = 5198;
@@ -29,9 +29,10 @@ export const TEST_SUBGRAPH_ID = new SubgraphDeploymentID(
 export const REQUEST_CID = utils.hexZeroPad('0x1', 32);
 export const RESPONSE_CID = utils.hexZeroPad('0x2', 32);
 // We want to use the same chainId that we use in the payment manager/ receipt manager
-export const CHAIN_ID = BigNumber.from(
-  defaultTestConfig().networkConfiguration.chainNetworkID
-).toNumber();
+export const CHAIN_ID = process.env.CHAIN_NETWORK_ID
+  ? parseInt(process.env.CHAIN_NETWORK_ID)
+  : defaultTestConfig().networkConfiguration.chainNetworkID;
+
 export const VERIFYING_CONTRACT = constants.AddressZero;
 
 export const TEST_GRAPHQL_RESPONSE = 'OK';

--- a/packages/e2e-testing/src/payment-server.ts
+++ b/packages/e2e-testing/src/payment-server.ts
@@ -19,7 +19,8 @@ import {BigNumber, constants, Wallet} from 'ethers';
 import {BN} from '@statechannels/wallet-core';
 import {
   defaultTestConfig,
-  overwriteConfigWithDatabaseConnection
+  overwriteConfigWithDatabaseConnection,
+  ServerWalletConfig
 } from '@statechannels/server-wallet';
 import {Address} from '@graphprotocol/statechannels-contracts';
 import {ETHERLIME_ACCOUNTS} from '@statechannels/devtools';
@@ -32,7 +33,8 @@ import {
   PAYER_PRIVATE_KEY,
   REQUEST_CID,
   TEST_SUBGRAPH_ID,
-  TEST_ATTESTATION_APP_ADDRESS
+  TEST_ATTESTATION_APP_ADDRESS,
+  CHAIN_ID
 } from './constants';
 
 type MessageSenderConfig = {
@@ -148,6 +150,20 @@ const createTasks = (logger: Logger) => ({
     logFile
   }: AnyArgs & {messageSenderConfig: MessageSenderConfig}) => {
     const messageSender = constructMessageSender(messageSenderConfig);
+    const walletConfig: ServerWalletConfig = defaultTestConfig({
+      workerThreadAmount: Number(amountOfWorkerThreads),
+      databaseConfiguration: {connection: {database: pgDatabase}},
+      chainServiceConfiguration: {
+        attachChainService: !!process.env.RPC_ENDPOINT,
+        provider: process.env.RPC_ENDPOINT,
+        pk: ETHERLIME_ACCOUNTS[0].privateKey
+      },
+      loggingConfiguration: {
+        logDestination: logFile,
+        logLevel: 'trace'
+      },
+      networkConfiguration: {chainNetworkID: CHAIN_ID}
+    });
 
     const channelManager = await ChannelManager.create({
       logger: logger.child({module: 'PaymentManager'}) as any,
@@ -161,20 +177,7 @@ const createTasks = (logger: Logger) => ({
       useLedger,
       syncOpeningChannelsPollIntervalMS: 2500,
       ensureAllocationsConcurrency: 10,
-
-      walletConfig: defaultTestConfig({
-        workerThreadAmount: Number(amountOfWorkerThreads),
-        databaseConfiguration: {connection: {database: pgDatabase}},
-        chainServiceConfiguration: {
-          attachChainService: !!process.env.RPC_ENDPOINT,
-          provider: process.env.RPC_ENDPOINT,
-          pk: ETHERLIME_ACCOUNTS[0].privateKey
-        },
-        loggingConfiguration: {
-          logDestination: logFile,
-          logLevel: 'trace'
-        }
-      }),
+      walletConfig,
       backoffStrategy: {
         numAttempts: 1,
         initialDelay: 50

--- a/packages/e2e-testing/src/receipt-server.ts
+++ b/packages/e2e-testing/src/receipt-server.ts
@@ -14,6 +14,7 @@ import {Logger, NetworkContracts} from '@graphprotocol/common-ts';
 
 import {createTestLogger, generateAttestations} from './utils';
 import {
+  CHAIN_ID,
   RECEIPT_PRIVATE_KEY,
   RECEIPT_SERVER_PORT,
   RECEIPT_SERVER_URL,
@@ -70,7 +71,8 @@ const commands = {
         loggingConfiguration: {
           logDestination: args.logFile,
           logLevel: 'trace'
-        }
+        },
+        networkConfiguration: {chainNetworkID: CHAIN_ID}
       } as const;
 
       const receiptManager = await ReceiptManager.create(

--- a/packages/payments/src/__tests__/payment-manager.test.ts
+++ b/packages/payments/src/__tests__/payment-manager.test.ts
@@ -97,8 +97,8 @@ beforeAll(async (done) => {
     defaultTestConfig({
       databaseConfiguration: {connection: {database: PAYMENT_MANAGER_TEST_DB_NAME}},
       networkConfiguration: {
-        chainNetworkID: process.env.CHAIN_ID
-          ? parseInt(process.env.CHAIN_ID)
+        chainNetworkID: process.env.CHAIN_NETWORK_ID
+          ? parseInt(process.env.CHAIN_NETWORK_ID)
           : defaultTestConfig().networkConfiguration.chainNetworkID
       },
       chainServiceConfiguration: {


### PR DESCRIPTION
# Description
Consistently set the `chainId` to `process.env.CHAIN_NETWORK_ID` .


I noticed this error in the [logs](https://app.circleci.com/pipelines/github/statechannels/graph-payments/152/workflows/806e9863-796a-4d58-b360-37cf04008c4a/jobs/1010/artifacts):

```
RuntimeError: VM Exception while processing transaction: revert Incorrect chainId\
```

Upon investigation, I confirmed that we're not actually setting the `networkChainID` properly in various wallet configurations used for e2e-testing.

 This PR fixes that (and works around [this issue](https://app.zenhub.com/workspaces/state-channels-5ff743783009980020a72feb/issues/statechannels/statechannels/3317)).

## Testing

 [This branch](https://github.com/statechannels/graph-payments/pull/48) includes this change and has a `chain` e2e test enabled. By viewing the [logs](https://1175-321823772-gh.circle-artifacts.com/0/tmp/e2e-test-with-ledger-with-chain.log) I've verified that we now see the correct `chainNetworkId` of `9002` .

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
